### PR TITLE
Optimizing info()

### DIFF
--- a/easyimage.js
+++ b/easyimage.js
@@ -18,7 +18,7 @@ function info(file, callback) {
 	file = quoted_name(file);
 	// %z = depth, %m = type, %w = width, %h = height, %b = filesize in byte, %f = filename
 	imcmd = 'identify -format "%m %z %w %h %b %f" ' + file;
-	console.log(imcmd);
+	
 	child = exec(imcmd, function(err, stdout, stderr) {
 		var info = {};
 		//Basic error handling:


### PR DESCRIPTION
I had some strange results when using the _info()_ method on a RedHat server with a slightly outdated version of ImageMagick, so i changed the call to _identify_ and the parsing of the output.
I use the _-format_ option to guarantee a well formated output....well hopefully. ;-)

Tested with ImageMagick 6.7.6 on OS X and on RHEL (can't check the version currently).
