### PR TITLE
Add options in resize and change in width/height management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ EasyImage offers these methods:
 	easyimg.info(<image_path>, <callback_function>) - to retrieve information about an image (name, type, width, height, size, depth)
 	easyimg.convert(<options>, <callback_function>) - to convert an image from one format to another
 	easyimg.resize(<options>, <callback_function>) - to resize an image
+	easyimg.resize_if_bigger(<options>, <callback_function>) - to resize an image only if bigger than destination. If smaller simply copy it.
 	easyimg.crop(<options>, <callback_function>) - to crop an image
 	easyimg.thumbnail(<options>, <callback_function>) - to create square thumbnails
 	easyimg.rescrop(<options>, <callback_function>) - to resize and crop and image in one go, useful for creating customzied thumbnails

--- a/easyimage.js
+++ b/easyimage.js
@@ -66,7 +66,7 @@ exports.convert = function(options, callback) {
 };
 
 // resize an image
-exports.resize = function(options, callback) {
+var resize = function(options, callback) {
 	if (options.src === undefined || options.dst === undefined) throw_err('path');
 	if (options.width === undefined && options.height === undefined) throw_err('dim'); 
 	options.height = options.height || "";
@@ -93,6 +93,32 @@ exports.resize = function(options, callback) {
 		if (err) throw err;
 		info(options.dst, callback);
 	});
+};
+
+exports.resize = function(options, callback) {
+    resize(options, callback);
+};
+
+// resize an image if src is bigger than dst otherwise copy it
+exports.resize_if_bigger = function(options, callback) {
+    if (options.src === undefined || options.dst === undefined) throw_err('path');
+    if (options.width === undefined && options.height === undefined) throw_err('dim'); 
+    options.height = options.height || "";
+    options.width = options.width || "";
+    options.src = quoted_name(options.src);
+    options.dst = quoted_name(options.dst);
+    var resize_cb = function(err, info, stderr) {
+	if (err) throw err;
+	if ((options.width && info.width < options.width) ||
+	    (options.height && info.height < options.height)) {
+	    // src is smaller than dst => copy it
+            var cmd = 'cp '+options.src+' '+options.dst;
+	    child = exec(cmd, callback);
+	} else {
+	    resize(options, callback);
+	}
+    };
+    info(options.src, resize_cb);
 };
 
 // crop an image

--- a/test.js
+++ b/test.js
@@ -48,6 +48,18 @@ easyimg.resize({src:srcimg,
 		   console.log(image);
 	       });
 
+easyimg.resize_if_bigger({src:srcimg, dst:'resize_if_bigger.jpg', width:640, height:480}, function(err, image) {
+	if (err) throw err;
+	console.log('Resized');
+	console.log(image);
+});
+
+easyimg.resize_if_bigger({src:srcimg, dst:'resize_copied.jpg', width:5000, height:5000}, function(err, image) {
+	if (err) throw err;
+	console.log('Copied');
+	console.log(image);
+});
+
 easyimg.crop(
 	{
 		src:srcimg, dst:'crop.jpg',


### PR DESCRIPTION
Hi I made some changes to easyimage.resize.

I added some options:
- colorspace: resize with colorspace correction
- density: specify density for output image (eg. 72x72 for 72dpi)
- strip: strip metadata

I also made changes to width and height and this might introduce some backward incompatibility.
You can pass to convert only the width or the height. In either case convert will resize the image mantaining aspect ratio.

Example of the convert command supposing width=300:
$ convert srcfile -geometry 300x destfile

Example convert command supposing height=500:
$ convert srcfile -geometry x500 destfile

Please consider the pull request for inclusion if the backward incompatibility is not a problem for you.
