### PR TITLE
refactored to change all throw statements to pass errors to callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,8 @@ Initial release
 ------------------
 
 1. Unsupported files should not crash
+
+0.1.2 - 27-05-2012
+------------------
+
+1. refactored to pass all errors to callback instead of throwing since nodejs does not pass thrown exceptions up the call stack as expected

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "easyimage",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "A user-friendly module for processing images in Node.js.",
 	"main": "easyimage.js",
 	"author": "Hack Sparrow <captain@hacksparrow.com>",


### PR DESCRIPTION
Since nodejs does not pass thrown exceptions up the callback stack the way one might expect, typically errors are handled by passing them to the provided callback.  Refactored to use this style of error handling.
