### PR TITLE
Weird error with chained callbacks.

### DIFF
--- a/easyimage.js
+++ b/easyimage.js
@@ -40,7 +40,6 @@ function info(file, callback) {
 				info.name   = temp.slice(5).join(' ').replace(/(\r\n|\n|\r)/gm,'');
 				
 				callback(err, info, stderr);
-				process.exit();
 				return;
 			}
 		}


### PR DESCRIPTION
I found that if I pass a nonexistent file and the module is used in chained callbacks the process doesn't exit and the script locks.
So I added process.exit to each exec call where an error exists.
