### PR TITLE
Update easyimage.js

### DIFF
--- a/easyimage.js
+++ b/easyimage.js
@@ -152,8 +152,8 @@ exports.thumbnail = function(options, callback) {
 		else if (original.height > original.width) { resizeheight = ''; }
 
 		// resize and crop
-		if (options.quality === undefined) imcmd = 'convert ' + options.src + ' -resize ' + resizewidth + 'x' + resizeheight + ' -gravity ' + options.gravity + ' -crop '+ options.width + 'x'+ options.height + '+' + options.x + '+' + options.y + ' ' + options.dst;
-		else imcmd = 'convert ' + options.src + ' -resize '+ resizewidth + 'x' + resizeheight + ' -quality ' + options.quality + ' -gravity ' + options.gravity + ' -crop '+ options.width + 'x'+ options.height + '+' + options.x + '+' + options.y + ' -quality ' + options.quality + ' ' + options.dst;
+		if (options.quality === undefined) imcmd = 'convert ' + options.src + ' -interpolate bicubic -strip -thumbnail ' + resizewidth + 'x' + resizeheight + ' -gravity ' + options.gravity + ' -crop '+ options.width + 'x'+ options.height + '+' + options.x + '+' + options.y + ' ' + options.dst;
+		else imcmd = 'convert ' + options.src + ' -interpolate bicubic -strip -thumbnail '+ resizewidth + 'x' + resizeheight + ' -quality ' + options.quality + ' -gravity ' + options.gravity + ' -crop '+ options.width + 'x'+ options.height + '+' + options.x + '+' + options.y + ' ' + options.dst;
 
 		child = exec(imcmd, function(err, stdout, stderr) {
 			if (err) return callback(err);


### PR DESCRIPTION
Hi,
I modified the thumbnail generation commands slightly, thought I'd give you a pull request, feel free to use or ignore as you see appropriate :)

However, I'd definitely recommend using "-strip" for thumbnails to remove all the metadata.

Changes:
Using "-thumbnail" to create thumbnail (appears to be twice as fast).
Using "-interpolate bicubic" to better mimic Photoshop's "save for web"
Using "-strip" to remove color profile, etc as it's not needed for thumbnails (greater than 50% file size saving on a thumbnail of 300x300px, much bigger file size saving on smaller ones).
