### PR TITLE
Add an option to shrink an image only if its dimension(s) are larger than the passed width and/or height arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ EasyImage offers these promise methods:
 	quality - quality of processed image, 1 to 100
 	gravity - crop position [NorthWest | North | NorthEast | West | Center | East | SouthWest | South | SouthEast], defaults to Center
 	fill - fill area flag, image is resized to completely fill the target crop dimensions, defaults to false
-  largeronly - shrink an image only if its dimension(s) are larger than the corresponding width and/or height arguments
+	largeronly - shrink an image only if its dimension(s) are larger than the corresponding width and/or height arguments
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ EasyImage offers these promise methods:
 	quality - quality of processed image, 1 to 100
 	gravity - crop position [NorthWest | North | NorthEast | West | Center | East | SouthWest | South | SouthEast], defaults to Center
 	fill - fill area flag, image is resized to completely fill the target crop dimensions, defaults to false
+  largeronly - shrink an image only if its dimension(s) are larger than the corresponding width and/or height arguments
 
 ## Examples
 

--- a/easyimage.js
+++ b/easyimage.js
@@ -101,10 +101,14 @@ exports.resize = function(options) {
 		if (options.width === undefined) return deferred.reject(error_messages['dim']);
 
 		options.height = options.height || options.width;
+		options.largeronly = !!options.largeronly || '';
 		// options.src = quoted_name(options.src);
 		// options.dst = quoted_name(options.dst);
-		if (options.quality === undefined) args = [options.src, '-resize', options.width + 'x' + options.height, options.dst];
-		else args = [options.src, '-resize', options.width + 'x' + options.height, '-quality', options.quality, options.dst];
+
+		if (options.largeronly) options.largeronly = '\\>';
+
+		if (options.quality === undefined) args = [options.src, '-resize', options.width + 'x' + options.height + options.largeronly, options.dst];
+		else args = [options.src, '-resize', options.width + 'x' + options.height + options.largeronly, '-quality', options.quality, options.dst];
 
 		child = exec('convert', args, function(err, stdout, stderr) {
 			if (err) deferred.reject(err);
@@ -190,8 +194,11 @@ exports.thumbnail = function(options) {
 		options.gravity = options.gravity || 'Center';
 		options.x = options.x || 0;
 		options.y = options.y || 0;
+		options.largeronly = !!options.largeronly || '';
 		// options.src = quoted_name(options.src);
 		// options.dst = quoted_name(options.dst);
+
+		if (options.largeronly) options.largeronly = '\\>';
 
 		info(options.src).then(function(original) {
 
@@ -206,8 +213,8 @@ exports.thumbnail = function(options) {
 			else if (original.height > original.width) { resizeheight = ''; }
 
 			// resize and crop
-			if (options.quality === undefined) args = [options.src, '-interpolate', 'bicubic', '-strip', '-thumbnail',  resizewidth + 'x' + resizeheight, '-gravity', options.gravity, '-crop', options.width + 'x'+ options.height + '+' + options.x + '+' + options.y, options.dst];
-			else args = [options.src, '-interpolate', 'bicubic', '-strip', '-thumbnail', resizewidth + 'x' + resizeheight, '-quality', options.quality, '-gravity', options.gravity, '-crop', options.width + 'x'+ options.height + '+' + options.x + '+' + options.y, options.dst];
+			if (options.quality === undefined) args = [options.src, '-interpolate', 'bicubic', '-strip', '-thumbnail',  resizewidth + 'x' + resizeheight + options.largeronly, '-gravity', options.gravity, '-crop', options.width + 'x'+ options.height + '+' + options.x + '+' + options.y, options.dst];
+			else args = [options.src, '-interpolate', 'bicubic', '-strip', '-thumbnail', resizewidth + 'x' + resizeheight + options.largeronly, '-quality', options.quality, '-gravity', options.gravity, '-crop', options.width + 'x'+ options.height + '+' + options.x + '+' + options.y, options.dst];
 
 			child = exec('convert', args, function(err, stdout, stderr) {
 				if (err) return deferred.reject(err);

--- a/easyimage.js
+++ b/easyimage.js
@@ -105,7 +105,7 @@ exports.resize = function(options) {
 		// options.src = quoted_name(options.src);
 		// options.dst = quoted_name(options.dst);
 
-		if (options.largeronly) options.largeronly = '\\>';
+		if (options.largeronly) options.largeronly = '>';
 
 		if (options.quality === undefined) args = [options.src, '-resize', options.width + 'x' + options.height + options.largeronly, options.dst];
 		else args = [options.src, '-resize', options.width + 'x' + options.height + options.largeronly, '-quality', options.quality, options.dst];
@@ -198,7 +198,7 @@ exports.thumbnail = function(options) {
 		// options.src = quoted_name(options.src);
 		// options.dst = quoted_name(options.dst);
 
-		if (options.largeronly) options.largeronly = '\\>';
+		if (options.largeronly) options.largeronly = '>';
 
 		info(options.src).then(function(original) {
 

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir);
 
 var easyimg = require('./easyimage.js');
 var srcimg = 'kitten.jpg';
+var srcimgwidth = 800;
 var warningimg = 'letter.png';
 
 describe('.info - ', function () {
@@ -72,6 +73,17 @@ describe('.resize -', function () {
             file.should.be.a('object');
             file.should.have.property('width');
             file.width.should.be.equal(640);
+            file.name.should.be.equal('resize.jpg');
+        });
+
+    });
+
+    it('should only resize larger images when "largeronly" option is set', function () {
+
+        return easyimg.resize({src:srcimg, dst:'./output/resize.jpg', width:1000, height:1000, largeronly: true}).then(function (file) {
+            file.should.be.a('object');
+            file.should.have.property('width');
+            file.width.should.be.equal(srcimgwidth);
             file.name.should.be.equal('resize.jpg');
         });
 
@@ -153,6 +165,22 @@ describe('.thumbnail -', function () {
             file.should.be.a('object');
             file.should.have.property('width');
             file.width.should.be.equal(128);
+            file.name.should.be.equal('thumbnail.jpg');
+        });
+
+    });
+
+    it('should only generate a thumbnail for larger images when "largeronly" option is set', function () {
+
+        return easyimg.thumbnail({
+            src:srcimg, dst:'./output/thumbnail.jpg',
+            width:1000, height:1000,
+            x:0, y:0,
+            largeronly: true
+        }).then(function (file) {
+            file.should.be.a('object');
+            file.should.have.property('width');
+            file.width.should.be.equal(srcimgwidth);
             file.name.should.be.equal('thumbnail.jpg');
         });
 


### PR DESCRIPTION
I've added the "largeronly" option to "resize()" and "thumbnail()" method in order to give the user the possibility to shrink an image only if its dimension(s) are larger than the passed width and/or height arguments.

Very useful, when users upload files.

Hope that helps.