### PR TITLE
Fix 'fill' and 'gravity' parameters in rescrop.

### DIFF
--- a/easyimage.js
+++ b/easyimage.js
@@ -199,7 +199,7 @@ exports.rescrop = function(options) {
 		// options.dst = quoted_name(options.dst);
 		options.fill = options.fill ? '^' : '';
 		if (options.quality === undefined) args = [options.src, '-resize', options.width + 'x' + options.height + options.fill, '-gravity', options.gravity, '-crop', options.cropwidth + 'x'+ options.cropheight + '+' + options.x + '+' + options.y, options.dst];
-		else args = [options.src, '-resize', options.width + 'x' + options.height, options.fill, '-gravity' + options.gravity, '-crop', options.cropwidth + 'x'+ options.cropheight + '+' + options.x + '+' + options.y, '-quality', options.quality, options.dst];
+		else args = [options.src, '-resize', options.width + 'x' + options.height + options.fill, '-gravity', options.gravity, '-crop', options.cropwidth + 'x'+ options.cropheight + '+' + options.x + '+' + options.y, '-quality', options.quality, options.dst];
 
 		child = exec('convert', args, function(err, stdout, stderr) {
 			if (err) deferred.reject(err);

--- a/test.js
+++ b/test.js
@@ -159,6 +159,23 @@ describe('.rescrop -', function () {
 
     });
 
+    it('should resize and crop with fill and quality specified', function () {
+
+        return easyimg.rescrop({
+            src:srcimg, dst:'./output/rescrop.jpg',
+            width:200, height:205,
+            fill: true,
+            quality: 75
+        }).then(function (file) {
+            file.should.be.a('object');
+            file.should.have.property('width');
+            file.width.should.be.equal(200)
+            file.height.should.be.equal(205);
+            file.name.should.be.equal('rescrop.jpg');
+        });
+
+    });
+
 });
 
 describe('.thumbnail -', function () {


### PR DESCRIPTION
This fixes issue #56 

I've included a test case to demonstrate the issue.

This actually fixes the same thing as pull-request #47 ... I actually didn't see that until I was in the process of creating this pull-request, but I decided to still open this since it includes a test for the issue as well.