### PR TITLE
Remove 'Undefined' from identify command stdout (Fixes hacksparrow/node-...

### DIFF
--- a/easyimage.js
+++ b/easyimage.js
@@ -41,7 +41,7 @@ function info(file) {
 
 		//Basic error handling
 		if (stdout) {
-			var temp = stdout.replace('PixelsPerInch', '').replace('PixelsPerCentimeter', '').split(' ');
+            var temp = stdout.replace(/PixelsPerInch/g, '').replace(/PixelsPerCentimeter/g, '').replace(/Undefined/g, '').split(/\s+/g);
 
 			//Basic error handling:
 			if (temp.length < 7) {


### PR DESCRIPTION
...easyimage#32)

Fixes a couple issues:
 1. Remove all occurences of `PixelsPerInch` and `PixelsPerCentimeter` and not only the first one
 2. Also remove all occurences of `Undefined` when IM is not able to extract the unit

I'm not sure the string replacement is the best solution here. I kept if for backward compatibility but it's a bit fragile. Also, if an image contains the strings `PixelsPerInch` or `PixelsPerCentimeter` or `Undefined` in its name, it will be removed.
A better solution would be to just split the string and ignore the items in the array that correspond to the density.