### PR TITLE
Replace shortid to nanoid

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -17,7 +17,7 @@ var fs_1 = require("fs");
 var mkdirp = require("mkdirp");
 var os_1 = require("os");
 var path_1 = require("path");
-var shortid_1 = require("shortid");
+var nanoid = require("nanoid");
 var BadDestinationError_1 = require("./errors/BadDestinationError");
 var MissingExtensionError_1 = require("./errors/MissingExtensionError");
 var MissingOptionsError_1 = require("./errors/MissingOptionsError");
@@ -97,6 +97,6 @@ function makeTemporaryFile(sourceFile) {
     if (!extension) {
         throw new MissingExtensionError_1.MissingExtensionError(sourceFile);
     }
-    var fileName = shortid_1.generate();
+    var fileName = nanoid();
     return os_1.tmpdir() + "/EasyImage-" + fileName + extension;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,15 @@
       "integrity": "sha512-fwTTP5QLf4xHMkv7ovcKvmlLWX3GrxCa5DRQDOilVyYGCp+arZTAQJCy7/4GKezzYJjfWMpB/Cy4e8nrc9XioA==",
       "dev": true
     },
+    "@types/nanoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nanoid/-/nanoid-1.0.0.tgz",
+      "integrity": "sha512-iMZIqTO1KxByOtwG2abOp2fufp9+rnwzCnX5LWp+h4JyX8Fw9/vKOPJ35Po9HFReuiq2yDGl4qdKJ3KS/RF9Xw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "4.2.23"
+      }
+    },
     "@types/node": {
       "version": "4.2.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
@@ -120,12 +129,6 @@
       "requires": {
         "@types/node": "4.2.23"
       }
-    },
-    "@types/shortid": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/shortid/-/shortid-0.0.29.tgz",
-      "integrity": "sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=",
-      "dev": true
     },
     "@types/sinon": {
       "version": "4.1.3",
@@ -709,6 +712,11 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nanoid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.0.2.tgz",
+      "integrity": "sha512-sCTwJt690lduNHyqknXJp8pRwzm80neOLGaiTHU2KUJZFVSErl778NNCIivEQCX5gNT0xR1Jy3HEMe/TABT6lw=="
+    },
     "nise": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
@@ -853,11 +861,6 @@
         "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
-    },
-    "shortid": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.8.tgz",
-      "integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE="
     },
     "sinon": {
       "version": "4.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easyimage",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "A promise-based, user-friendly module for processing images in Node.js",
   "license": "MIT",
   "main": "lib/easyimage.js",
@@ -43,7 +43,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "mkdirp": "^0.5.0",
-    "shortid": "^2.2.8",
+    "nanoid": "^1.0.2",
     "tslib": "^1.8.1",
     "typescript": "^2.6.2"
   },
@@ -53,9 +53,9 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/mkdirp": "^0.5.2",
     "@types/mocha": "^2.2.46",
+    "@types/nanoid": "^1.0.0",
     "@types/node": "=4",
     "@types/rimraf": "^2.0.2",
-    "@types/shortid": "0.0.29",
     "@types/sinon": "^4.1.3",
     "@types/sinon-chai": "^2.7.29",
     "chai": "^4.1.2",

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -16,7 +16,7 @@ import {exists} from "fs";
 import * as mkdirp from "mkdirp";
 import {tmpdir} from "os";
 import {dirname, extname} from "path";
-import {generate} from "shortid";
+import nanoid = require("nanoid");
 import {BadDestinationError} from "./errors/BadDestinationError";
 import {MissingExtensionError} from "./errors/MissingExtensionError";
 import {MissingOptionsError} from "./errors/MissingOptionsError";
@@ -105,6 +105,6 @@ function makeTemporaryFile(sourceFile: string) {
     if (!extension) {
         throw new MissingExtensionError(sourceFile);
     }
-    const fileName = generate();
+    const fileName = nanoid();
     return `${tmpdir()}/EasyImage-${fileName}${extension}`;
 }


### PR DESCRIPTION
I replaced ID generator because of:

1. `shortid` has no maintenance anymore.
2. `shortid` has some dangerous issues in tracker like bad distribution (higher collision probability).
3. [`nanoid`](https://github.com/ai/nanoid) is safer and 9 times faster than `shortid`
4. There were no changes for project users. Only a little better performance and smaller `node_modules`. You will have safer ID generator with better support.

@mrkmg what do you think about it? I am not sure that I used the best way to require `nanoid` in TS.